### PR TITLE
Use a custom tooltip for the debug label's tooltip, with better looks

### DIFF
--- a/addons/debug_watermark/debug_watermark.tscn
+++ b/addons/debug_watermark/debug_watermark.tscn
@@ -40,20 +40,31 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Tooltip" type="PanelContainer" parent="DebugLabel"]
-visible = false
-margin_right = 360.0
-margin_bottom = 120.0
-rect_min_size = Vector2( 380, 120 )
+[node name="Tooltip" type="MarginContainer" parent="DebugLabel"]
+margin_right = 440.0
+margin_bottom = 140.0
+custom_constants/margin_right = 10
+custom_constants/margin_top = 10
+custom_constants/margin_left = 10
+custom_constants/margin_bottom = 10
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="PanelContainer" type="PanelContainer" parent="DebugLabel/Tooltip"]
+margin_left = 10.0
+margin_top = 10.0
+margin_right = 430.0
+margin_bottom = 130.0
 custom_styles/panel = SubResource( 1 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="MarginContainer" type="MarginContainer" parent="DebugLabel/Tooltip"]
+[node name="MarginContainer" type="MarginContainer" parent="DebugLabel/Tooltip/PanelContainer"]
 margin_left = 1.0
 margin_top = 1.0
-margin_right = 379.0
+margin_right = 419.0
 margin_bottom = 119.0
 custom_constants/margin_right = 10
 custom_constants/margin_top = 10
@@ -63,13 +74,14 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="RichTextLabel" type="RichTextLabel" parent="DebugLabel/Tooltip/MarginContainer"]
+[node name="RichTextLabel" type="RichTextLabel" parent="DebugLabel/Tooltip/PanelContainer/MarginContainer"]
 margin_left = 10.0
 margin_top = 10.0
-margin_right = 368.0
+margin_right = 408.0
 margin_bottom = 108.0
 size_flags_vertical = 3
 bbcode_enabled = true
 fit_content_height = true
 scroll_active = false
+
 [connection signal="gui_input" from="DebugLabel" to="." method="_on_DebugLabel_gui_input"]

--- a/addons/debug_watermark/debug_watermark.tscn
+++ b/addons/debug_watermark/debug_watermark.tscn
@@ -1,10 +1,24 @@
-[gd_scene load_steps=2 format=2]
+[gd_scene load_steps=4 format=2]
 
 [ext_resource path="res://addons/debug_watermark/debug_watermark.gd" type="Script" id=1]
+[ext_resource path="res://addons/debug_watermark/debug_watermark_label.gd" type="Script" id=3]
+
+[sub_resource type="StyleBoxFlat" id=1]
+bg_color = Color( 0.658824, 0.87451, 1, 0.25098 )
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color( 0.156863, 0.45098, 0.647059, 0.25098 )
+border_blend = true
+corner_radius_top_left = 2
+corner_radius_top_right = 2
+corner_radius_bottom_right = 2
+corner_radius_bottom_left = 2
 
 [node name="DebugWatermark" type="CanvasLayer"]
 script = ExtResource( 1 )
-tooltip = "{project_name} {project_version} on {engine_platform}
+tooltip = "[color=purple]{project_name}[/color] {project_version} on [color=navy]{engine_platform}[/color]
 Godot version: {engine_version}
 Website: {project_website}
 
@@ -21,7 +35,41 @@ custom_colors/font_color_shadow = Color( 0.309804, 0.054902, 0.054902, 0.501961 
 text = "Debug build"
 align = 2
 valign = 2
+script = ExtResource( 3 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
+
+[node name="Tooltip" type="PanelContainer" parent="DebugLabel"]
+visible = false
+margin_right = 360.0
+margin_bottom = 120.0
+rect_min_size = Vector2( 380, 120 )
+custom_styles/panel = SubResource( 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="MarginContainer" type="MarginContainer" parent="DebugLabel/Tooltip"]
+margin_left = 1.0
+margin_top = 1.0
+margin_right = 379.0
+margin_bottom = 119.0
+custom_constants/margin_right = 10
+custom_constants/margin_top = 10
+custom_constants/margin_left = 10
+custom_constants/margin_bottom = 10
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="RichTextLabel" type="RichTextLabel" parent="DebugLabel/Tooltip/MarginContainer"]
+margin_left = 10.0
+margin_top = 10.0
+margin_right = 368.0
+margin_bottom = 108.0
+size_flags_vertical = 3
+bbcode_enabled = true
+fit_content_height = true
+scroll_active = false
 [connection signal="gui_input" from="DebugLabel" to="." method="_on_DebugLabel_gui_input"]

--- a/addons/debug_watermark/debug_watermark_label.gd
+++ b/addons/debug_watermark/debug_watermark_label.gd
@@ -7,7 +7,12 @@ func _ready():
 
 func _make_custom_tooltip(for_text):
 	var tooltip = $Tooltip.duplicate()
-	var rtl = tooltip.get_node("MarginContainer/RichTextLabel")
+	# Must be made visible beforehand, otherwise Viewport size calculations
+	# would be incorrect (see https://github.com/godotengine/godot/issues/39677).
+	tooltip.visible = true
+	var rtl = tooltip.get_node("PanelContainer/MarginContainer/RichTextLabel")
 	rtl.bbcode_text = for_text
+	# Work around https://github.com/godotengine/godot/issues/18260.
+	rtl.rect_min_size = rtl.rect_size
 	return tooltip
 

--- a/addons/debug_watermark/debug_watermark_label.gd
+++ b/addons/debug_watermark/debug_watermark_label.gd
@@ -1,0 +1,13 @@
+extends Label
+
+
+func _ready():
+	$Tooltip.hide()
+
+
+func _make_custom_tooltip(for_text):
+	var tooltip = $Tooltip.duplicate()
+	var rtl = tooltip.get_node("MarginContainer/RichTextLabel")
+	rtl.bbcode_text = for_text
+	return tooltip
+


### PR DESCRIPTION
Took me a while (as seen with the respective age of the two commits) due to some engine issues I had to workaround or figure out.

Looks like this:
![Screenshot_20201102_155530](https://user-images.githubusercontent.com/4701338/97882381-da644f80-1d23-11eb-823e-4b18fdc2a4eb.png)
